### PR TITLE
Fix bug in path detection when ninka.pl called from its own directory.

### DIFF
--- a/ninka.pl
+++ b/ninka.pl
@@ -57,7 +57,7 @@ my $delete = exists $opts{d};
 
 my $path = $0;
 
-$path =~ s/\/+[^\/]+$//;
+$path =~ s/\/*[^\/]+$//;
 if ($path eq "") {
     $path = "./";
 }


### PR DESCRIPTION
When attempting to use ninka for the first time, I executed it from its own directory:

```
╭ < yaauie@beorn ~/src/ninka (master =) >
╰ $ perl ninka.pl -v ../redis/COPYING
/Users/yaauie/src/ninkaStarting: ../redis/COPYING;
../redis/COPYING;Creating comments file:Running ninka.pl/extComments/extComments.pl -v -c1 '../redis/COPYING':sh: ninka.pl/extComments/extComments.pl: Not a directory
execution of program [ninka.pl/extComments/extComments.pl -v -c1 '../redis/COPYING'] failed: status [126] at ninka.pl line 168.
```

This small patch allows the script to be executed from its parent's directory, while still allowing the standard case.