### PR TITLE
Avoid "which" cluttering stderr

### DIFF
--- a/lib/Ninka/CommentExtractor.pm
+++ b/lib/Ninka/CommentExtractor.pm
@@ -45,7 +45,7 @@ sub determine_comments_command {
             return create_head_cmd($input_file, 400);
         } elsif ($ext =~ /^(java|c|cpp|h|cxx|c\+\+|cc)$/) {
             my $comments_binary = 'comments';
-            if (`which $comments_binary` ne '') {
+            if (!system("which $comments_binary > /dev/null 2>&1")) {
                 return ($comments_binary, "-c1", $input_file);
             } else {
                 return create_head_cmd($input_file, 400);


### PR DESCRIPTION
If the given executable is not in PATH, the "which" command line program
prints an error to stderr. Avoid that by piping all output to /dev/null
and querying the exit code instead of stdout.
