### PR TITLE
Add other binaries

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,7 +13,7 @@ WriteMakefile(
         'Yuki Manabe <y-manabe@ist.osaka-u.ac.jp>',
         'René Scheibe <rene.scheibe@gmail.com>',
     ],
-    EXE_FILES => ['bin/ninka'],
+    EXE_FILES => ['bin/ninka','bin/ninka-excel','bin/ninka-sqlite'],
     CONFIGURE_REQUIRES => {
         'ExtUtils::MakeMaker' => '6.52',
     },


### PR DESCRIPTION
The -excel and -sqlite executables were missing, even though their prereqs were there.