### PR TITLE
Fix regular expression in SentenceExtractor

### DIFF
--- a/lib/Ninka/SentenceExtractor.pm
+++ b/lib/Ninka/SentenceExtractor.pm
@@ -114,7 +114,7 @@ sub clean_sentence {
 
     # check for trailing bullets of different types
     s/^o //;
-    s/^\s*[0-9]{1-2}+\s*[\-\)]//;
+    s/^\s*[0-9]{1,2}+\s*[\-\)]//;
     s/^[ \t]+//;
     s/[ \t]+$//;
 


### PR DESCRIPTION
When starting ninka, the following message was printed:

  Unescaped left brace in regex is deprecated here
  (and will be fatal in Perl 5.30), passed through in regex;
  marked by <-- HERE in m/^\s*[0-9]{ <-- HERE 1-2}+\s*[\-\)]/
  at Ninka/SentenceExtractor.pm line 117.