### PR TITLE
replace deprecated IO::CaptureOutput with Capture::Tiny, and cleanup IPC::Open3

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,6 @@ WriteMakefile(
         'File::Spec::Functions' => '0',
         'File::Temp' => '0',
         'Getopt::Std' => '0',
-        'IPC::Open3' => '0',
         'Spreadsheet::WriteExcel' => '0',
         'Capture::Tiny' => '0',
     },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,8 +27,7 @@ WriteMakefile(
         'Getopt::Std' => '0',
         'IPC::Open3' => '0',
         'Spreadsheet::WriteExcel' => '0',
-        'IO::CaptureOutput' => '0',
-                  
+        'Capture::Tiny' => '0',
     },
     TEST_REQUIRES => {
         'File::Temp' => '0',

--- a/lib/Ninka/CommentExtractor.pm
+++ b/lib/Ninka/CommentExtractor.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use IPC::Open3 'open3';
 use Symbol 'gensym';
-use IO::CaptureOutput qw/capture_exec/;
+use Capture::Tiny qw/capture/;
 
 sub new {
     my ($class, %args) = @_;
@@ -70,7 +70,7 @@ sub execute_command {
     #    otherwise system will use the shell to do the execution
     die "command (@command) seems to be missing parameters" unless (scalar(@command) > 1);
 
-    my ($stdout, $error, $success, $status) = capture_exec( @command );
+    my ($stdout, $error, $status) = capture { system( @command ) };
 
     my $commandSt = join(' ', @command);
     die "execution of program [$commandSt] failed: status [$status], error [$error]" if ($status != 0);

--- a/lib/Ninka/CommentExtractor.pm
+++ b/lib/Ninka/CommentExtractor.pm
@@ -2,7 +2,6 @@ package Ninka::CommentExtractor;
 
 use strict;
 use warnings;
-use IPC::Open3 'open3';
 use Symbol 'gensym';
 use Capture::Tiny qw/capture/;
 
@@ -81,24 +80,24 @@ sub execute_command {
 
 # insecure execute command. Leave here for the time being
 # it is dead code
-sub execute_command_old {
-    my ($command) = @_;
-
-    if ($command =~ /&/) {
-        die "illegal file name in command to be executed [$command]";
-    }
-
-    my ($child_in, $child_out, $child_err);
-    $child_err = gensym();
-    my $pid = open3($child_in, $child_out, $child_err, $command);
-    my $comments = do { local $/; <$child_out> };
-    chomp(my $error = join('; ', <$child_err>));
-    waitpid $pid, 0;
-    my $status = ($? >> 8);
-    die "execution of program [$command] failed: status [$status], error [$error]" if ($status != 0);
-
-    return $comments;
-}
+#sub execute_command_old {
+#    my ($command) = @_;
+#
+#    if ($command =~ /&/) {
+#        die "illegal file name in command to be executed [$command]";
+#    }
+#
+#    my ($child_in, $child_out, $child_err);
+#    $child_err = gensym();
+#    my $pid = open3($child_in, $child_out, $child_err, $command);
+#    my $comments = do { local $/; <$child_out> };
+#    chomp(my $error = join('; ', <$child_err>));
+#    waitpid $pid, 0;
+#    my $status = ($? >> 8);
+#    die "execution of program [$command] failed: status [$status], error [$error]" if ($status != 0);
+#
+#    return $comments;
+#}
 
 1;
 

--- a/lib/Ninka/FileCleaner.pm
+++ b/lib/Ninka/FileCleaner.pm
@@ -2,7 +2,6 @@ package Ninka::FileCleaner;
 
 use strict;
 use warnings;
-use IPC::Open3 'open3';
 use Symbol 'gensym';
 
 sub new {


### PR DESCRIPTION
IO::CaptureOutput is deprecated and the author recommends Capture::Tiny which is widely used in the Perl community today. See also https://metacpan.org/pod/IO::CaptureOutput#DESCRIPTION

And IPC::Open3 is actually not used in the code, so I would suggest completely remove it. 